### PR TITLE
Fix afl-collect with non-UTF-8 characters

### DIFF
--- a/afl_utils/AflThread.py
+++ b/afl_utils/AflThread.py
@@ -85,11 +85,11 @@ class GdbThread(threading.Thread):
     def run(self):
         try:
             script_output = subprocess.check_output(" ".join(self.gdb_cmd), shell=True, stderr=subprocess.DEVNULL,
-                                                    stdin=subprocess.DEVNULL, universal_newlines=True)
+                                                    stdin=subprocess.DEVNULL)
         except (subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
             script_output = e.output
 
-        script_output = script_output.splitlines()
+        script_output = script_output.decode(errors='replace').splitlines()
 
         for line in script_output:
             matching = [line.replace(g, '') for g in self.grep_for if g in line]


### PR DESCRIPTION
Fixes this exception when gdb output contains bytes that cannot be decoded as UTF-8:
````
Executing gdb+exploitable script 'gdb_script.0'...
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/home/mark/afl/afl-utils/afl_utils/AflThread.py", line 88, in run
    stdin=subprocess.DEVNULL, universal_newlines=True)
  File "/usr/lib/python3.4/subprocess.py", line 609, in check_output
    output, unused_err = process.communicate(inputdata, timeout=timeout)
  File "/usr/lib/python3.4/subprocess.py", line 949, in communicate
    stdout = _eintr_retry_call(self.stdout.read)
  File "/usr/lib/python3.4/subprocess.py", line 491, in _eintr_retry_call
    return func(*args)
  File "/usr/lib/python3.4/codecs.py", line 319, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 1939: invalid start byte
````