### PR TITLE
Adding option to minimize crashes filenames

### DIFF
--- a/afl_utils/SampleIndex.py
+++ b/afl_utils/SampleIndex.py
@@ -18,12 +18,19 @@ import os
 
 
 class SampleIndex:
-    def __init__(self, output_dir, index=[]):
+    def __init__(self, output_dir, index=[], min_filename=False):
         self.output_dir = os.path.abspath(output_dir)
         self.index = index
+        self.min_filename = min_filename
 
     def __generate_output__(self, fuzzer, input_file):
-        return "%s:%s" % (fuzzer, os.path.basename(input_file))
+        input_filename = os.path.basename(input_file)
+        if self.min_filename:
+            try:
+                input_filename = input_filename.split(",")[0].split(":")[1]
+            except Exception:
+                pass
+        return "%s:%s" % (fuzzer, input_filename)
 
     def __remove__(self, key, values):
         self.index = [x for x in self.index if x[key] not in values]


### PR DESCRIPTION
I was fuzzing a target that breaks when the input filename contained certain characters. This commit adds an option for keeping the name of collected crashes to the minimum.

I'm not sure if this is worth to merge, but just keeping it here just in case anyone else has the same issue I faced.