### PR TITLE
Update 'job' parameter help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Usage:
 
     positional arguments:
       cmd                   afl-multicore command to execute: start, resume, add.
-      jobs                  Number of slave instances to start/resume/add.
+      jobs                  Number of instances to start/resume/add.
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/afl_utils/afl_multicore.py
+++ b/afl_utils/afl_multicore.py
@@ -248,7 +248,7 @@ in the background. For fuzzer stats see 'out_dir/SESSION###/fuzzer_stats'!",
                         default=False, help="For debugging purposes do not redirect stderr/stdout of the created \
 subprocesses to /dev/null (Default: off). Check 'nohup.out' for further outputs.")
     parser.add_argument("cmd", help="afl-multicore command to execute: start, resume, add.")
-    parser.add_argument("jobs", help="Number of slave instances to start/resume/add.")
+    parser.add_argument("jobs", help="Number of instances to start/resume/add.")
 
     args = parser.parse_args(argv[1:])
 


### PR DESCRIPTION
It specifies the total number of jobs, not the number of slaves.

Fixes #18