### PR TITLE
Implement support for --chmod and --chown rsync flags (supersedes PR #46)

### DIFF
--- a/afl_utils/afl_sync.py
+++ b/afl_utils/afl_sync.py
@@ -183,7 +183,7 @@ locations. Supported are remote transfers through rsync that may use transport c
             rsync_put_options.append("--chmod={}".format(args.chmod))
 
         if args.chown:
-            rsync_put_options.append("--chown={}".format(args.chown))
+            rsync_put_options.append(["--protect-args", "--chown={}".format(args.chown)])
 
     if not os.path.exists(args.src_sync_dir):
         if args.cmd in ['pull', 'sync']:

--- a/afl_utils/afl_sync.py
+++ b/afl_utils/afl_sync.py
@@ -154,7 +154,7 @@ locations. Supported are remote transfers through rsync that may use transport c
                         help='Affect destination\'s file and directory permissions, e.g. --chmod=g+rw to add '
                              'read/write group permissions.', metavar="PERMS")
     parser.add_argument('--chown',
-                        help='Affect destination\'s file and directory user and group, e.g. --chmod=foo:bar to '
+                        help='Affect destination\'s file and directory user and group, e.g. --chown=foo:bar to '
                         'let the files be owned by user foo and group bar.', metavar="USER:GROUP")
     parser.add_argument('-S', '--session', dest='session', default=None,
                         help='Name of an afl-multicore session. If provided, only fuzzers belonging to '

--- a/afl_utils/afl_sync.py
+++ b/afl_utils/afl_sync.py
@@ -176,8 +176,7 @@ locations. Supported are remote transfers through rsync that may use transport c
         # these arguments are meaningless with pull since they should only
         # affect the remote side
         if args.cmd == 'pull':
-            print_err('Sorry, --chmod and --chown are meaningless with pull.')
-            sys.exit(1)
+            print_warn('--chmod and --chown have no effect with pull and will be ignored.')
 
         if args.chmod:
             rsync_put_options.append("--chmod={}".format(args.chmod))

--- a/tests/test_afl_sync.py
+++ b/tests/test_afl_sync.py
@@ -196,7 +196,6 @@ class AflSyncTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists('testdata/rsync_output_push/fuzz000.sync'))
         self.assertFalse(os.path.exists('testdata/rsync_output_push/fuzz000.sync/.cur_input'))
         self.assertTrue(os.path.exists('testdata/rsync_output_push/fuzz001.sync'))
-        self.assertFalse(os.path.exists('testdata/rsync_output_push/fuzz000.sync/.cur_input'))
         self.assertFalse(os.path.exists('testdata/rsync_output_push/fuzz002.sync'))
         self.assertFalse(os.path.exists('testdata/rsync_output_push/fuzz002.sync.sync'))
         self.assertFalse(os.path.exists('testdata/rsync_output_push/invalid_fuzz000.sync'))


### PR DESCRIPTION
I've implemented most of the things you asked for, except testing the new features. I'm not sure how to approach testing the `--chown` functionality since I don't know which users/groups I can rely on being present in the testing environment.

Regarding `--chmod`, I have started implementing tests but I'm not sure what's the best way to organize them. I've thought about making a new `test_chmod` sync dir with a single file inside it with certain permissions set up, then adding a new test case `test_afl_rsync_chmod` which tests push/sync by using `--chmod` to change permissions and verifying they are correct (by calling `AflRsync` directly). How does that sound?

I'm in a bit of a hurry, so sorry if something's unclear.